### PR TITLE
Fix artifact conflicts in matrix jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: '0 0 * * 0'
 
 permissions:
   contents: read

--- a/dist/main.js
+++ b/dist/main.js
@@ -6244,9 +6244,6 @@ function requireToolCache () {
 
 var toolCacheExports = requireToolCache();
 
-const artifactName = `${process.env.GITHUB_JOB}-octometrics.monitor.log.jsonl`;
-const monitorPath = '/tmp/' + artifactName;
-
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
@@ -6257,6 +6254,9 @@ async function run() {
     const arch = require$$0.arch();
 
     const jobName = coreExports.getInput('job_name', { required: true });
+    const safeJobName = jobName.replace(/["/:<>|*?\\]/g, '-');
+    const artifactName = `${safeJobName}-octometrics.monitor.log.jsonl`;
+    const monitorPath = '/tmp/' + artifactName;
     process.env.GITHUB_JOB_NAME = jobName;
 
     const skipComment = coreExports.getBooleanInput('skip_comment', {

--- a/dist/post.js
+++ b/dist/post.js
@@ -172372,15 +172372,17 @@ var artifactExports = requireArtifact();
  * This runs after the main action completes, regardless of success or failure.
  */
 
-const artifactName = `${process.env.GITHUB_JOB}-octometrics.monitor.log.jsonl`;
-const monitorPath = '/tmp/' + artifactName;
-
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 async function run() {
   try {
+    const jobName = coreExports.getInput('job_name', { required: true });
+    const safeJobName = jobName.replace(/["/:<>|*?\\]/g, '-');
+    const artifactName = `${safeJobName}-octometrics.monitor.log.jsonl`;
+    const monitorPath = '/tmp/' + artifactName;
+
     // Check if we're running in a GitHub Actions environment
     const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
     const hasRuntimeToken = !!process.env.ACTIONS_RUNTIME_TOKEN;
@@ -172417,6 +172419,7 @@ async function run() {
     }
 
     coreExports.info('Uploading octometrics monitor data...');
+    coreExports.info(`Artifact name: ${artifactName}`);
 
     // Create artifact client
     const artifactClient = new artifactExports.DefaultArtifactClient();

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.15.0",
         "eslint-plugin-prettier": "^5.5.5",
+        "globals": "^17.4.0",
         "jest": "^30.3.0",
         "make-coverage-badge": "^1.2.0",
         "prettier": "^3.8.1",
@@ -5681,6 +5682,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -14582,6 +14596,12 @@
       "requires": {
         "is-glob": "^4.0.3"
       }
+    },
+    "globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true
     },
     "globalthis": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.0",
     "eslint-plugin-prettier": "^5.5.5",
+    "globals": "^17.4.0",
     "jest": "^30.3.0",
     "make-coverage-badge": "^1.2.0",
     "prettier": "^3.8.1",

--- a/src/main.js
+++ b/src/main.js
@@ -6,9 +6,6 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { spawn } from 'child_process'
 
-const artifactName = `${process.env.GITHUB_JOB}-octometrics.monitor.log.jsonl`
-const monitorPath = '/tmp/' + artifactName
-
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
@@ -19,6 +16,9 @@ export async function run() {
     const arch = os.arch()
 
     const jobName = core.getInput('job_name', { required: true })
+    const safeJobName = jobName.replace(/["/:<>|*?\\]/g, '-')
+    const artifactName = `${safeJobName}-octometrics.monitor.log.jsonl`
+    const monitorPath = '/tmp/' + artifactName
     process.env.GITHUB_JOB_NAME = jobName
 
     const skipComment = core.getBooleanInput('skip_comment', {

--- a/src/post.js
+++ b/src/post.js
@@ -6,15 +6,17 @@ import * as core from '@actions/core'
 import { execSync } from 'child_process'
 import { DefaultArtifactClient } from '@actions/artifact'
 
-const artifactName = `${process.env.GITHUB_JOB}-octometrics.monitor.log.jsonl`
-const monitorPath = '/tmp/' + artifactName
-
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 export async function run() {
   try {
+    const jobName = core.getInput('job_name', { required: true })
+    const safeJobName = jobName.replace(/["/:<>|*?\\]/g, '-')
+    const artifactName = `${safeJobName}-octometrics.monitor.log.jsonl`
+    const monitorPath = '/tmp/' + artifactName
+
     // Check if we're running in a GitHub Actions environment
     const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
     const hasRuntimeToken = !!process.env.ACTIONS_RUNTIME_TOKEN
@@ -51,6 +53,7 @@ export async function run() {
     }
 
     core.info('Uploading octometrics monitor data...')
+    core.info(`Artifact name: ${artifactName}`)
 
     // Create artifact client
     const artifactClient = new DefaultArtifactClient()


### PR DESCRIPTION
Fixes an issue where matrix jobs conflict when uploading artifacts because `process.env.GITHUB_JOB` does not include matrix suffixes. Uses a sanitized `job_name` input instead. Also includes the requested debug logging of the artifact name.

---
*PR created automatically by Jules for task [6972633644719502292](https://jules.google.com/task/6972633644719502292) started by @kalverra*